### PR TITLE
Crash on melee hit in monster groups

### DIFF
--- a/src/melee2.c
+++ b/src/melee2.c
@@ -4395,7 +4395,7 @@ void tell_ally_death(monster_type *n_ptr, int u, int v, int w)
 bool tell_allies_death(int y, int x, cptr saying)
 {
 	/* Something said? */
-	return (tell_allies_info(y, x, NULL, (int)saying, 0, 0, TRUE, NULL, tell_ally_death));
+	return (tell_allies_info(y, x, saying, 0, 0, 0, TRUE, NULL, tell_ally_death));
 }
 
 


### PR DESCRIPTION
Wrong argument order in melee2.c:4398 tell_allies_death causes an occasional crash at melee2.c:4147 tell_allies_info by executing strlen(NULL). This happens to me sometimes when melee fighting groups of monsters as an unarmed warrior in the Bree dungeon levels. With this fix I've cleared multiple dungeons without experiencing crashes.