### PR TITLE
Updated terrain with true color Black option, including suggestion for black unexplored space.

### DIFF
--- a/lib/edit/terrain.txt
+++ b/lib/edit/terrain.txt
@@ -30,10 +30,11 @@
 # 'G' is for graphics - symbol and color. There are 16 colors, as
 # follows:
 
-# D - Black        w - White          s - Gray          o - Orange
+# d - Black        w - White          s - Gray          o - Orange
 # r - Red          g - Green          b - Blue          u - Brown
 # d - Dark Gray    W - Light Gray     v - Violet        y - Yellow
 # R - Light Red    G - Light Green    B - Light Blue    U - Light Brown
+# D - Dark Gray
 
 # 'W' is for where the feature appears, its rarity, the priority number used
 # when viewing the condensed map, and the index of a feature that surrounds
@@ -386,7 +387,7 @@ V:0.6.6
 # 0x00 --> nothing
 
 N:0:nothing
-G: :w
+G: :d
 O:0
 W:0:0:0:0
 F:ATTR_LITE |
@@ -421,7 +422,7 @@ F:HURT_POIS | HURT_WATER | ATTR_LITE |
 # 0x02 --> invisible trap (drawn as open floor)
 
 N:2:invisible trap
-G:x:D
+G:x:d
 M:1
 #$ open floor
 U:56
@@ -3582,7 +3583,7 @@ F:OUTSIDE | ATTR_LITE |
 #Chasm center.
 
 N:141:chasm
-G: :D
+G: :d
 O:0
 W:45:2:1:142
 #$ chasm


### PR DESCRIPTION
Terrain.txt states 'D' is Black. Actually defines.h:5308 states 'd' is Black and 'D' is Dark Gray. Updated reference, also terrain 'nothing' and 'chasm' to 'd' Black as a formality, since they already use the space character. All other Dark Gray terrain seems right. Maybe unexplored space as a 'D' Dark Gray 'x' character is an intentional Unangband variant decision, but I prefer playing with a 'd' Dark 'x' character. This offers more clarity in dungeon levels on x11, especially in forest dungeon areas such as Barrow-downs. Only changing the color, not the character in case any code requires unexplored space to be character 'x'.