### PR TITLE
Avoid scary tmpnam warning for linux build.

### DIFF
--- a/src/Makefile.std
+++ b/src/Makefile.std
@@ -48,7 +48,7 @@ SYS_gcu = -DUSE_GCU -DUSE_NCURSES -lncurses
 
 # Basic compiler stuff
 CC = gcc
-CFLAGS = -Wall -O2 -Wno-unused-parameter
+CFLAGS = -Wall -O2 -Wno-unused-parameter -DHAVE_MKSTEMP
 
 
 # Add additional search directives here


### PR DESCRIPTION
Use HAVE_MKSTEMP definition for linux build to avoid a scary compiler warning about tmpnam. Linux can use the safer mkstemp just like osx.