### PR TITLE
New display option: Display emergent narrative

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -113,7 +113,7 @@
  * into the main window. So in these instances, we cheat, and shrink it slightly to 12.
  *
  */
-#define SIDEBAR_WID		(show_sidebar ? (use_dbltile || use_trptile ? 12 : 13) : 0)
+#define SIDEBAR_WID		(show_sidebar | show_narrative ? (use_dbltile || use_trptile ? 12 : 13) : 0)
 
 
 #define ROW_MAP			1

--- a/src/dungeon.c
+++ b/src/dungeon.c
@@ -3427,7 +3427,12 @@ static void process_player(void)
 
 	/* Update scent trail */
 	update_smell();
-
+	
+	/* If narrative shown, update narrative */
+	if (show_narrative)
+	{
+		print_emergent_narrative();
+	}
 
 	/*
 	 * Reset character vulnerability.  Will be calculated by

--- a/src/externs.h
+++ b/src/externs.h
@@ -1170,6 +1170,7 @@ extern void update_stuff(void);
 extern void redraw_stuff(void);
 extern void window_stuff(void);
 extern void handle_stuff(void);
+extern int print_emergent_narrative(void);
 
 /* xtra2.c */
 extern bool set_timed(int idx, int v, bool notify);
@@ -1229,7 +1230,7 @@ extern void get_zone(dungeon_zone **zone_handle, int dungeon, int depth);
 extern void long_level_name(char* str, int town, int depth);
 extern void current_long_level_name(char* str);
 extern int scale_method(method_level_scalar_type scalar, int level);
-
+extern void get_room_desc(int room, char *name, int name_s, char *text_visible, int text_visible_s, char *text_always, int text_always_s);
 
 /*
  * Hack -- conditional (or "bizarre") externs

--- a/src/option.c
+++ b/src/option.c
@@ -48,6 +48,7 @@ const byte option_page[OPT_PAGE_MAX][OPT_PAGE_PER] =
 
 	/* Display */
 	{
+		OPT_show_narrative,
 		OPT_hilite_player,
  		OPT_center_player,
 		OPT_show_piles,
@@ -260,7 +261,7 @@ static option_entry options[OPT_MAX] =
 { "easy_monlist",        "Spacebar toggles visible monsters/objects",   FALSE }, /* 107 */
 { "view_fogged_grids",   "Show fog of war for unexplored areas",        TRUE }, /* 108 */
 { "ally_messages",       "Show detailed combat messages for allies",    FALSE }, /* 109 */
-{ NULL,                  NULL,                                          FALSE }, /* 110 */
+{ "show_narrative",      "Display emergent narrative",                  TRUE }, /* 110 */
 { NULL,                  NULL,                                          FALSE }, /* 111 */
 { NULL,                  NULL,                                          FALSE }, /* 112 */
 { NULL,                  NULL,                                          FALSE }, /* 113 */

--- a/src/option.h
+++ b/src/option.h
@@ -102,6 +102,7 @@ extern const byte option_page[OPT_PAGE_MAX][OPT_PAGE_PER];
 #define OPT_easy_monlist  		 107
 #define OPT_view_fogged_grids	108
 #define OPT_ally_messages	109
+#define OPT_show_narrative	110
 
 #define OPT_birth_randarts          (OPT_BIRTH+1)
 #define OPT_birth_rand_stats        (OPT_BIRTH+2)
@@ -208,6 +209,7 @@ extern const byte option_page[OPT_PAGE_MAX][OPT_PAGE_PER];
 #define easy_search		  	OPT(easy_search)
 #define view_glowing_lite 	OPT(view_glowing_lite)
 #define show_sidebar      	OPT(show_sidebar)
+#define show_narrative      	OPT(show_narrative)
 #define show_itemlist      OPT(show_itemlist)
 #define depth_in_feet      OPT(depth_in_feet)
 #define view_flavors       OPT(view_flavors)

--- a/src/xtra2.c
+++ b/src/xtra2.c
@@ -3414,7 +3414,7 @@ bool change_panel(int dir)
 /*
  * Hack - generate the current room description
  */
-static void get_room_desc(int room, char *name, int name_s, char *text_visible, int text_visible_s, char *text_always, int text_always_s)
+void get_room_desc(int room, char *name, int name_s, char *text_visible, int text_visible_s, char *text_always, int text_always_s)
 {
 	bool scan_name = FALSE;
 	bool scan_desc = FALSE;


### PR DESCRIPTION
Unangband has stories to tell with its emergent gameplay and dynamic descriptions. I think this is Unangband's most unique and distinctive feature, but it requires players to actively examine everything. This feature tries to create an active emergent narrative using visible monsters, objects, noticeable features and various room texts, visible also when traversing and revisiting dungeon rooms. With this feature active, Unangband's dynamic narrative is always visible, immediately noticeable and helpful to anyone playing Unangband, creating a more immersive experience especially in dungeons.

I playtested mostly in starting towns and dungeons. I also play seriously with this feature on, because I love to read everything, not having to memorize ASCII symbols and the faster pacing with it. Please let me know if I can improve the code or feature in any way.