### PR TITLE
Suggestion: allow playing Unangband on systems without base xfonts

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -528,6 +528,8 @@
 #define DEFAULT_X11_FONT_6		"5x8"
 #define DEFAULT_X11_FONT_7		"5x8"
 
+#define FALLBACK_X11_FONT		"*fixed*"
+
 
 /*
  * Hack -- Special "ancient machine" versions

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -2384,7 +2384,12 @@ static errr term_data_init(term_data *td, int i)
 	/* Prepare the standard font */
 	td->fnt = ZNEW(infofnt);
 	Infofnt_set(td->fnt);
-	if (Infofnt_init_data(font)) quit_fmt("Couldn't load the requested font. (%s)", font);
+	if (Infofnt_init_data(font)) {
+		printf("\nUsing sys font, please install base xfonts (reboot required).\n\n");
+
+		if (Infofnt_init_data(FALLBACK_X11_FONT))
+			quit_fmt("Please install base xfonts (reboot required). (%s)", font);
+	}
 
 	/* Hack -- key buffer size */
 	num = ((i == 0) ? 1024 : 16);


### PR DESCRIPTION
Lubuntu 17.10 does not have base xfonts by default. Unangband won't start and provides no clear instructions. This change will try to find a fallback fixed font if the base xfonts are missing and recommends installing base xfonts in the terminal. With this change, Unangband does work on a clean Lubuntu 17.10 install.