### PR TITLE
Suggestion: recommend popular modern Terminus xfonts for x11 (main term only)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -528,6 +528,8 @@
 #define DEFAULT_X11_FONT_6		"5x8"
 #define DEFAULT_X11_FONT_7		"5x8"
 
+#define FALLBACK_X11_FONT		"*fixed*"
+
 
 /*
  * Hack -- Special "ancient machine" versions

--- a/src/config.h
+++ b/src/config.h
@@ -519,6 +519,7 @@
 /*
  * OPTION: Default fonts (when using X11)
  */
+#define MODERN_X11_FONT			"terminus-18"
 #define DEFAULT_X11_FONT_0		"10x20"
 #define DEFAULT_X11_FONT_1		"9x15"
 #define DEFAULT_X11_FONT_2		"9x15"

--- a/src/maid-x11.c
+++ b/src/maid-x11.c
@@ -93,6 +93,24 @@ u32b create_pixel(Display *dpy, byte red, byte green, byte blue)
 }
 
 
+bool has_env_font(int term_num)
+{
+	cptr font;
+	char buf[80];
+	
+	/* Window specific font name */
+	sprintf(buf, "ANGBAND_X11_FONT_%d", term_num);
+	
+	/* Check environment for that font */
+	font = getenv(buf);
+	
+	/* Check environment for "base" font */
+	if (!font) font = getenv("ANGBAND_X11_FONT");
+	
+	return (font ? (bool) 1 : (bool) 0);
+}
+
+
 /*
  * Get the name of the default font to use for the term.
  */

--- a/src/maid-x11.h
+++ b/src/maid-x11.h
@@ -60,6 +60,7 @@
 
 
 extern u32b create_pixel(Display *dpy, byte red, byte green, byte blue);
+extern bool has_env_font(int term_num);
 extern cptr get_default_font(int term_num);
 extern XImage *ReadBMP(Display *dpy, char *Name);
 extern bool smoothRescaling;

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -2384,7 +2384,12 @@ static errr term_data_init(term_data *td, int i)
 	/* Prepare the standard font */
 	td->fnt = ZNEW(infofnt);
 	Infofnt_set(td->fnt);
-	if (Infofnt_init_data(font)) quit_fmt("Couldn't load the requested font. (%s)", font);
+	if (Infofnt_init_data(font)) {
+		printf("\nUsing sys font, please install base xfonts (reboot required).\n\n");
+
+		if (Infofnt_init_data(FALLBACK_X11_FONT))
+			quit_fmt("Please install base xfonts (reboot required). (%s)", font);
+	}
 
 	/* Hack -- key buffer size */
 	num = ((i == 0) ? 1024 : 16);

--- a/src/main-x11.c
+++ b/src/main-x11.c
@@ -2334,6 +2334,8 @@ static errr term_data_init(term_data *td, int i)
 	char res_name[20];
 	char res_class[20];
 
+	bool is_main_term = (i == 0);
+
 	XSizeHints *sh;
 
 	/* Get default font for this term */
@@ -2384,11 +2386,25 @@ static errr term_data_init(term_data *td, int i)
 	/* Prepare the standard font */
 	td->fnt = ZNEW(infofnt);
 	Infofnt_set(td->fnt);
-	if (Infofnt_init_data(font)) {
-		printf("\nUsing sys font, please install base xfonts (reboot required).\n\n");
 
-		if (Infofnt_init_data(FALLBACK_X11_FONT))
-			quit_fmt("Please install base xfonts (reboot required). (%s)", font);
+	if (! has_env_font(i) && is_main_term) {
+		if (Infofnt_init_data(MODERN_X11_FONT)) {
+			printf("\nUsing base xfont, install Terminus xfonts for improved visuals.\n");
+
+			if (Infofnt_init_data(font)) {
+				printf("\nUsing sys font, please install Terminus/base xfonts (reboot required).\n\n");
+
+				if (Infofnt_init_data(FALLBACK_X11_FONT))
+					quit_fmt("Please install xfonts (Terminus or base, reboot required). (%s)", font);
+			}
+		}
+	} else {
+		if (Infofnt_init_data(font)) {
+			printf("\nUsing sys font, please install base xfonts (reboot required).\n\n");
+
+			if (Infofnt_init_data(FALLBACK_X11_FONT))
+				quit_fmt("Please install base xfonts (reboot required). (%s)", font);
+		}
 	}
 
 	/* Hack -- key buffer size */


### PR DESCRIPTION
Use xfonts priority: user defined, else Terminus, else base xfonts, else fallback fixed fonts. Terminus fonts used only for the main terminal. Recommend Terminus xfonts in terminal for improved visuals if not available.